### PR TITLE
A simple fix to remove the usage of Astropy TestRunner due to deprecation

### DIFF
--- a/edge_pydb/__init__.py
+++ b/edge_pydb/__init__.py
@@ -1,4 +1,4 @@
-from ._astropy_init import __version__, test
+from ._astropy_init import __version__
 from . import beam_sample, conversion, fitsextract, plotting, util
 from astropy.table import Table as _Table
 from astropy.table import join as _join

--- a/edge_pydb/_astropy_init.py
+++ b/edge_pydb/_astropy_init.py
@@ -2,9 +2,8 @@
 
 import os
 
-from astropy.tests.runner import TestRunner
 
-__all__ = ['__version__', 'test']
+__all__ = ['__version__', ]#'test']
 
 try:
     from .version import version as __version__
@@ -12,5 +11,6 @@ except ImportError:
     __version__ = ''
 
 # Create the test function for self test
-test = TestRunner.make_test_runner_in(os.path.dirname(__file__))
-test.__test__ = False
+# Need pytest function to run tests instead of astropy's TestRunner
+# test = TestRunner.make_test_runner_in(os.path.dirname(__file__))
+# test.__test__ = False


### PR DESCRIPTION
This is a simple patch to remove the warning in Issue #39. Resolves #39 